### PR TITLE
Add --allow-root to all wp-cli calls

### DIFF
--- a/vvv-init.sh
+++ b/vvv-init.sh
@@ -13,9 +13,9 @@ then
 	echo "Installing WordPress using WP CLI"
 	mkdir htdocs
 	cd htdocs
-	wp core download 
-	wp core config --dbname="vvv_demo_1" --dbuser=wp --dbpass=wp --dbhost="localhost"
-	wp core install --url=vvv-demo-1.dev --title="VVV Bootstrap Demo 1" --admin_user=admin --admin_password=password --admin_email=demo@example.com
+	wp core download --allow-root
+	wp core config --dbname="vvv_demo_1" --dbuser=wp --dbpass=wp --dbhost="localhost" --allow-root
+	wp core install --url=vvv-demo-1.dev --title="VVV Bootstrap Demo 1" --admin_user=admin --admin_password=password --admin_email=demo@example.com --allow-root
 	cd ..
 fi
 


### PR DESCRIPTION
wp-cli now requires --allow-root in order to run as the root user due to security concerns (see [wp-cli/wp-cli#982](https://github.com/wp-cli/wp-cli/issues/982) and [wp-cli/wp-cli#973](https://github.com/wp-cli/wp-cli/pull/973)).  I've added this flag to all uses of wp-cli in vvv-init.sh.
