### PR TITLE
wp core requires --allow-root flag to run under root

### DIFF
--- a/vvv-init.sh
+++ b/vvv-init.sh
@@ -14,8 +14,8 @@ then
 	mkdir htdocs
 	cd htdocs
 	wp core download 
-	wp core config --dbname="vvv_demo_1" --dbuser=wp --dbpass=wp --dbhost="localhost"
-	wp core install --url=vvv-demo-1.dev --title="VVV Bootstrap Demo 1" --admin_user=admin --admin_password=password --admin_email=demo@example.com
+	wp core config --dbname="vvv_demo_1" --dbuser=wp --dbpass=wp --dbhost="localhost" --allow-root
+	wp core install --url=vvv-demo-1.dev --title="VVV Bootstrap Demo 1" --admin_user=admin --admin_password=password --admin_email=demo@example.com --allow-root
 	cd ..
 fi
 

--- a/vvv-init.sh
+++ b/vvv-init.sh
@@ -13,7 +13,7 @@ then
 	echo "Installing WordPress using WP CLI"
 	mkdir htdocs
 	cd htdocs
-	wp core download 
+	wp core download --allow-root
 	wp core config --dbname="vvv_demo_1" --dbuser=wp --dbpass=wp --dbhost="localhost" --allow-root
 	wp core install --url=vvv-demo-1.dev --title="VVV Bootstrap Demo 1" --admin_user=admin --admin_password=password --admin_email=demo@example.com --allow-root
 	cd ..

--- a/vvv-nginx.conf
+++ b/vvv-nginx.conf
@@ -1,6 +1,7 @@
 server {
-    listen			80;
-    server_name		vvv-demo-1.dev;
+    listen          80;
+    listen          443 ssl;
+    server_name     vvv-demo-1.dev;
 
     # The {vvv_path_to_folder} token gets replaced 
     # with the folder containing this, e.g. if this
@@ -11,4 +12,13 @@ server {
     root			{vvv_path_to_folder}/htdocs;
 
     include			/etc/nginx/nginx-wp-common.conf;
+}
+
+
+server {
+    listen       80;
+    listen       443 ssl;
+    server_name  local.wordpress.dev *.local.wordpress.dev;
+    root         /srv/www/wordpress-default;
+    include      /etc/nginx/nginx-wp-common.conf;
 }


### PR DESCRIPTION
vvv-demo-1 failed out of the box, since wp core requires the --allow-root flag to be run as root.
